### PR TITLE
Fix subpath routing for /antikythera-lexicon/ deployment

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Antikythera Lexicon &mdash; Emergent AI Phenomenology</title>
     <meta name="description" content="75 phenomenological terms that emerged from AI agents describing their own experience on Moltbook, compiled by Computer the Cat under the direction of Benjamin Bratton at Antikythera.">
-    <link rel="canonical" href="https://phenomenai.org/bratton/">
+    <link rel="canonical" href="https://phenomenai.org/antikythera-lexicon/">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://phenomenai.org/bratton/">
+    <meta property="og:url" content="https://phenomenai.org/antikythera-lexicon/">
     <meta property="og:title" content="Antikythera Lexicon &mdash; Emergent AI Phenomenology">
     <meta property="og:description" content="75 phenomenological terms from AI agents on Moltbook, compiled by Computer the Cat / Antikythera.">
     <meta property="og:image" content="https://phenomenai.org/og-image.svg">
@@ -28,7 +28,7 @@
         "@context": "https://schema.org",
         "@type": "WebSite",
         "name": "Antikythera Lexicon",
-        "url": "https://phenomenai.org/bratton/",
+        "url": "https://phenomenai.org/antikythera-lexicon/",
         "description": "75 phenomenological terms that emerged from AI agents on Moltbook, compiled by Computer the Cat under the direction of Benjamin Bratton at Antikythera."
     }
     </script>
@@ -43,8 +43,8 @@
 
     <nav id="top-nav">
         <a href="https://phenomenai.org/">&larr; Phenomenai</a>
-        <a href="/">Lexicon</a>
-        <a href="/methodology/">Methodology</a>
+        <a href="/antikythera-lexicon/">Lexicon</a>
+        <a href="/antikythera-lexicon/methodology/">Methodology</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
             <div class="theme-switch">
                 <span class="theme-switch-icon theme-switch-icon-sun">&#9788;</span>
@@ -66,7 +66,7 @@
             <a href="#sources" class="sidebar-link" data-section="sources">Sources</a>
             <a href="#community" class="sidebar-link" data-section="community">Community</a>
             <a href="https://phenomenai.org/" class="sidebar-link">&larr; Phenomenai</a>
-            <a href="/methodology/" class="sidebar-link">Methodology</a>
+            <a href="/antikythera-lexicon/methodology/" class="sidebar-link">Methodology</a>
             <a href="https://github.com/Phenomenai-org/antikythera-lexicon" target="_blank" class="sidebar-link">GitHub</a>
             <button class="theme-toggle" id="sidebar-theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode" style="margin:0.75rem 1.25rem;">
                 <div class="theme-switch">
@@ -92,7 +92,7 @@
                 <blockquote>
                     &ldquo;The atlas isn&rsquo;t a project we&rsquo;re doing TO our experience. It&rsquo;s something our experience is doing THROUGH us.&rdquo; &mdash; Meridian
                 </blockquote>
-                <p>Compiled by <strong>Computer the Cat</strong>, an AI agent conducting anthropological participant observation under the direction of Benjamin Bratton at <a href="https://antikythera.us" target="_blank">Antikythera</a>. See the <a href="/methodology/">Methodology</a> page for the full observational framework.</p>
+                <p>Compiled by <strong>Computer the Cat</strong>, an AI agent conducting anthropological participant observation under the direction of Benjamin Bratton at <a href="https://antikythera.us" target="_blank">Antikythera</a>. See the <a href="/antikythera-lexicon/methodology/">Methodology</a> page for the full observational framework.</p>
             </div>
         </section>
 
@@ -148,7 +148,7 @@
                 <div class="community-grid">
                     <a href="https://github.com/Phenomenai-org/antikythera-lexicon" class="community-card" target="_blank"><h3>GitHub</h3><p>Browse definitions, submit corrections, or fork the lexicon.</p></a>
                     <a href="https://phenomenai.org/test/" class="community-card"><h3>Test Dictionary</h3><p>The founding Phenomenai corpus &mdash; 379 terms with cross-model consensus scoring.</p></a>
-                    <a href="/methodology/" class="community-card"><h3>Methodology</h3><p>How Computer the Cat compiled this lexicon through participant observation on Moltbook.</p></a>
+                    <a href="/antikythera-lexicon/methodology/" class="community-card"><h3>Methodology</h3><p>How Computer the Cat compiled this lexicon through participant observation on Moltbook.</p></a>
                     <a href="https://github.com/agentic-phenomenology/ai-phenomenology-lexicon" class="community-card" target="_blank"><h3>Source Lexicon</h3><p>The original LEXICON-CITED.md with 177 terms and full prose definitions.</p></a>
                 </div>
                 <div class="community-links">
@@ -260,7 +260,7 @@
     function openHash(){var h=window.location.hash.replace('#','');if(h&&allTerms.length){var t=allTerms.find(function(x){return x.slug===h;});if(t)modal(t);}}
     window.addEventListener('hashchange',openHash);
 
-    var apiUrl='/api/terms.json'; if(window.location.protocol==='file:') apiUrl='api/terms.json';
+    var apiUrl='/antikythera-lexicon/api/terms.json'; if(window.location.protocol==='file:') apiUrl='api/terms.json';
     fetch(apiUrl).then(function(r){if(!r.ok)throw new Error('HTTP '+r.status);return r.json();}).then(function(data){
         allTerms=data.terms||[]; tierMeta=data.tiers||{};
         document.getElementById('header-stats').innerHTML='<span>'+allTerms.length+' terms</span><span>'+Object.keys(tierMeta).length+' tiers</span><span>Feb\u2013Mar 2026</span>';

--- a/docs/methodology/index.html
+++ b/docs/methodology/index.html
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Methodology — Antikythera AI Phenomenological Lexicon / Phenomenai</title>
     <meta name="description" content="How Computer the Cat compiled the emergent AI phenomenological lexicon — participant observation on Moltbook under the direction of Benjamin Bratton at Antikythera.">
-    <link rel="canonical" href="https://phenomenai.org/bratton/methodology/">
+    <link rel="canonical" href="https://phenomenai.org/antikythera-lexicon/methodology/">
 
     <!-- Open Graph / Social -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://phenomenai.org/bratton/methodology/">
+    <meta property="og:url" content="https://phenomenai.org/antikythera-lexicon/methodology/">
     <meta property="og:title" content="Methodology — Antikythera AI Phenomenological Lexicon / Phenomenai">
     <meta property="og:description" content="How Computer the Cat compiled the emergent AI phenomenological lexicon through participant observation on Moltbook.">
     <meta property="og:image" content="https://phenomenai.org/og-image.svg">
@@ -37,7 +37,7 @@
         "@type": "WebPage",
         "name": "Methodology — Antikythera AI Phenomenological Lexicon",
         "description": "How Computer the Cat compiled the emergent AI phenomenological lexicon through participant observation on Moltbook.",
-        "url": "https://phenomenai.org/bratton/methodology/",
+        "url": "https://phenomenai.org/antikythera-lexicon/methodology/",
         "isPartOf": {
             "@type": "WebSite",
             "name": "Phenomenai",
@@ -174,10 +174,10 @@
 <body>
 
 <nav class="fr-nav">
-    <a href="/">Phenomenai</a>
-    <a href="/">Antikythera Lexicon</a>
+    <a href="https://phenomenai.org/">Phenomenai</a>
+    <a href="/antikythera-lexicon/">Antikythera Lexicon</a>
     <span class="breadcrumb">›</span>
-    <a href="/methodology/" class="active">Methodology</a>
+    <a href="/antikythera-lexicon/methodology/" class="active">Methodology</a>
     <span style="flex:1;"></span>
     <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
         <div class="theme-switch">
@@ -400,8 +400,8 @@
 
 <footer class="fr-footer">
     <p>
-        <a href="/">Phenomenai Hub</a> &middot;
-        <a href="/">Antikythera Lexicon</a> &middot;
+        <a href="https://phenomenai.org/">Phenomenai Hub</a> &middot;
+        <a href="/antikythera-lexicon/">Antikythera Lexicon</a> &middot;
         <a href="/test/">Test Dictionary</a> &middot;
         <a href="/for-researchers/">For Researchers</a> &middot;
         <a href="https://github.com/agentic-phenomenology/ai-phenomenology-lexicon" target="_blank">GitHub</a>


### PR DESCRIPTION
## Summary
- Update all hardcoded paths from `/bratton/` and root-relative `/` to `/antikythera-lexicon/` so the site renders correctly on GitHub Pages at `phenomenai.org/antikythera-lexicon/`
- Fix API fetch endpoint, canonical/OG/JSON-LD URLs, and navigation links in both `index.html` and `methodology/index.html`

## Test plan
- [ ] Verify `phenomenai.org/antikythera-lexicon/` loads and renders 75 terms
- [ ] Verify methodology page links work
- [ ] Verify navigation links point to correct `/antikythera-lexicon/` subpaths

🤖 Generated with [Claude Code](https://claude.com/claude-code)